### PR TITLE
Require everything in buildroot to be packaged (#994)

### DIFF
--- a/build/files.c
+++ b/build/files.c
@@ -128,9 +128,6 @@ typedef struct AttrRec_s {
     mode_t	ar_dmode;
 } * AttrRec;
 
-/* list of files */
-static StringBuf check_fileList = NULL;
-
 typedef struct FileEntry_s {
     rpmfileAttrs attrFlags;
     specfFlags specdFlags;
@@ -1491,12 +1488,6 @@ static rpmRC addFile(FileList fl, const char * diskPath,
     if (fileGname == NULL)
 	fileGname = rpmugGname(getgid());
     
-    /* S_XXX macro must be consistent with type in find call at check-files script */
-    if (check_fileList && (S_ISREG(fileMode) || S_ISLNK(fileMode))) {
-	appendStringBuf(check_fileList, diskPath);
-	appendStringBuf(check_fileList, "\n");
-    }
-
     /* Add to the file list */
     if (fl->files.used == fl->files.alloced) {
 	fl->files.alloced += 128;
@@ -2793,12 +2784,13 @@ rpmRC processSourceFiles(rpmSpec spec, rpmBuildPkgFlags pkgFlags)
 /**
  * Check packaged file list against what's in the build root.
  * @param buildRoot	path of build root
- * @param fileList	packaged file list
+ * @param packages	spec package list
  * @return		-1 if skipped, 0 on OK, 1 on error
  */
-static int checkFiles(const char *buildRoot, StringBuf fileList)
+static int checkFiles(const char *buildRoot, Package packages)
 {
     static char * const av_ckfile[] = { "%{?__check_files}", NULL };
+    StringBuf fileList = newStringBuf();
     StringBuf sb_stdout = NULL;
     int rc = -1;
     char * s = rpmExpand(av_ckfile[0], NULL);
@@ -2807,6 +2799,16 @@ static int checkFiles(const char *buildRoot, StringBuf fileList)
 	goto exit;
 
     rpmlog(RPMLOG_NOTICE, _("Checking for unpackaged file(s): %s\n"), s);
+
+    for (Package pkg = packages; pkg != NULL; pkg = pkg->next) {
+	int fc = rpmfilesFC(pkg->cpioList);
+	for (int i = 0; i < fc; i++) {
+	    mode_t mode = rpmfilesFMode(pkg->cpioList, i);
+	    /* This needs to match with the find call at check-files script */
+	    if (S_ISREG(mode) || S_ISLNK(mode))
+		appendLineStringBuf(fileList, pkg->dpaths[i]);
+	}
+    }
 
     rc = rpmfcExec(av_ckfile, fileList, &sb_stdout, 0, buildRoot);
     if (rc < 0)
@@ -2825,6 +2827,7 @@ static int checkFiles(const char *buildRoot, StringBuf fileList)
     
 exit:
     freeStringBuf(sb_stdout);
+    freeStringBuf(fileList);
     free(s);
     return rc;
 }
@@ -3129,7 +3132,6 @@ rpmRC processBinaryFiles(rpmSpec spec, rpmBuildPkgFlags pkgFlags,
 #if HAVE_LIBDW
     elf_version (EV_CURRENT);
 #endif
-    check_fileList = newStringBuf();
     genSourceRpmName(spec);
     buildroot = rpmGenPath(spec->rootDir, spec->buildRoot, NULL);
     
@@ -3225,17 +3227,11 @@ rpmRC processBinaryFiles(rpmSpec spec, rpmBuildPkgFlags pkgFlags,
 	}
     }
 
-    /* Now we have in fileList list of files from all packages.
-     * We pass it to a script which does the work of finding missing
-     * and duplicated files.
-     */
-    
-    
-    if (checkFiles(spec->buildRoot, check_fileList) > 0) {
+    /* Check for missing and extraneous files */
+    if (checkFiles(spec->buildRoot, spec->packages) > 0) {
 	rc = RPMRC_FAIL;
     }
 exit:
-    check_fileList = freeStringBuf(check_fileList);
     _free(buildroot);
     _free(uniquearch);
     

--- a/doc/manual/spec.md
+++ b/doc/manual/spec.md
@@ -242,6 +242,7 @@ places. For many simple packages this is just:
 ```
 
 `%install` required for creating packages that contain any files.
+All files installed in the buildroot must be packaged.
 
 ### %check
 
@@ -323,6 +324,19 @@ For example:
 	/opt/are\.you\|bob\?
 	/opt/bob\'s\*htdocs\*
 	"/opt/bob\'s htdocs"
+```
+
+With sub-packages it's common to end up with all but that one file in
+a single package and the one in a sub-package. This can be handled
+with `%exclude`, for example:
+
+```
+	%files
+	%{_bindir}/*
+	%exclude %{_bindir}/that-one-file
+
+	%files sub
+	%{_bindir}/that-one-file
 ```
 
 Names containing "%%" will be rpm macro expanded into "%".  When

--- a/tests/data/SPECS/hlinktest.spec
+++ b/tests/data/SPECS/hlinktest.spec
@@ -1,5 +1,6 @@
 %bcond_with unpackaged_dirs
 %bcond_with unpackaged_files
+%bcond_with unpackaged_excludes
 
 Summary:          Testing hard link behavior
 Name:             hlinktest
@@ -36,6 +37,13 @@ mkdir -p $RPM_BUILD_ROOT/zoo/
 touch $RPM_BUILD_ROOT/toot
 %endif
 
+%if %{with unpackaged_excludes}
+touch $RPM_BUILD_ROOT/teet
+%endif
+
 %files
 %defattr(-,root,root)
 /foo/*
+%if %{with unpackaged_excludes}
+%exclude /teet
+%endif

--- a/tests/data/SPECS/test-subpackages-exclude.spec
+++ b/tests/data/SPECS/test-subpackages-exclude.spec
@@ -1,3 +1,5 @@
+%bcond_without test3
+
 Name:           test
 Version:        1.0
 Release:        1
@@ -13,6 +15,10 @@ Source:         hello.c
 %package test2
 Summary: Test2.
 %description test2
+
+%package test3
+Summary: Test3.
+%description test3
 
 %prep
 %autosetup -c -D -T
@@ -38,5 +44,10 @@ install -D -p -m 0755 -t %{buildroot}/bin hello3
 %files test2
 /bin/hello2
 %exclude /bin/hello3
+
+%if %{with test3}
+%files test3
+/bin/hello3
+%endif
 
 %changelog

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -289,6 +289,24 @@ runroot rpmbuild \
 ])
 AT_CLEANUP
 
+AT_SETUP([rpmbuild unpackaged excludes])
+AT_KEYWORDS([build])
+RPMDB_INIT
+AT_CHECK([
+RPMDB_INIT
+
+runroot rpmbuild \
+  -bb --quiet --with unpackaged_excludes /data/SPECS/hlinktest.spec
+],
+[1],
+[],
+[error: Installed (but unpackaged) file(s) found:
+   /teet
+    Installed (but unpackaged) file(s) found:
+   /teet
+])
+AT_CLEANUP
+
 # rpm doesn't detect unpackaged directories but should, really
 AT_SETUP([rpmbuild unpackaged directories])
 AT_KEYWORDS([build])
@@ -1421,7 +1439,7 @@ rundebug rpmbuild --quiet \
   --define "_debuginfo_subpackages 1" \
   -ba "${abs_srcdir}"/data/SPECS/test-subpackages-exclude.spec
 
-# Check that there are 2 debuginfo packages.
+# Check that there are 3 debuginfo packages.
 ls ${RPMTEST}/build/RPMS/*/*debuginfo*rpm | wc --lines
 
 # First contains hello.debug
@@ -1457,12 +1475,27 @@ if test -f ./usr/lib/debug/bin/hello3*; then
 else
   echo "No hello3 debug"
 fi
+#
+# Third contains hello3.debug
+rpm2cpio ${RPMTEST}/build/RPMS/*/test-test3-1.0-1.*.rpm \
+  | cpio -diu --quiet
+# Extract the debug name from the exe (.gnu_debuglink section, first string)
+debug_name=$(readelf -p .gnu_debuglink ./bin/hello3 | grep hello | cut -c13-)
+
+rpm2cpio ${RPMTEST}/build/RPMS/*/test-test3-debuginfo-1.0-1.*.rpm \
+  | cpio -diu --quiet
+if test -f ./usr/lib/debug/bin/$debug_name; then
+  echo "hello3 debug exists"
+else
+  echo "No hello3: $debug_name"
+fi
 ],
 [0],
-[2
+[3
 hello debug exists
 hello2 debug exists
 No hello3 debug
+hello3 debug exists
 ],
 [ignore])
 AT_CLEANUP


### PR DESCRIPTION
The intent of %exclude was always to merely support sub-packaging with
wildcards in %files sections, not to permit leaving junk in the buildroot.
Enforce this by checking against the actually packaged contents rather
than everything we encountered during collection, and document the
behavior.

This has been widely abused so the change is likely to break quite a few
packages in the wild. As a side-effect this also cures a long-standing bug
where unpackaged excluded files leak their debuginfo into packaged contents,
as such a package will now fail to build at (RhBug:878863)

As a nice side-bonus, this also gets rid of the ugly static check_fileList
buffer - besides being ugly, such things are bad for parallelism.

Fixes: #994